### PR TITLE
further mocks and profiling tools

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -6,6 +6,8 @@ from .schemas import MovieSchema
 import json
 import time
 
+stats = {'total': 0, 'cached': 0}
+
 def get_movie_by_title(db: Session, title: str):
     cache_key = title.lower()
 
@@ -30,8 +32,10 @@ def get_movie_by_title(db: Session, title: str):
 
 def cache_get_movie_by_title(db: Session, title: str):
     cache_key = f"movie:{title.lower()}"
+    stats['total'] += 1
     cached = redis_client.get(cache_key)
     if cached:
+        stats['cached'] += 1
         return json.loads(cached)
 
     movies = db.query(models.Movie).filter(models.Movie.title.ilike(f"%{title}%")).limit(100).all()

--- a/app/main.py
+++ b/app/main.py
@@ -1,16 +1,27 @@
+from collections.abc import Iterator
+from datetime import datetime
+from itertools import cycle
 from fastapi import FastAPI, Depends, HTTPException, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 import json
+import cProfile
+import tempfile
+
+from . import mock
 
 from . import models, database, crud, schemas
 from .redis_client import redis_client
 
+profiler: cProfile.Profile|None = None
+
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 templates = Jinja2Templates(directory="app/templates")
+
+mock_movies: Iterator[list[mock.MockMovie]]
 
 models.Base.metadata.create_all(bind=database.engine)
 
@@ -44,6 +55,8 @@ def warmup_cache(db: Session):
 def startup_event():
     db = next(get_db())
     warmup_cache(db)
+    global mock_movies
+    mock_movies = cycle(mock.gen_mocks(db))
 
 @app.get("/", response_class=HTMLResponse)
 def read_index(request: Request):
@@ -56,6 +69,48 @@ def pong(request: Request):
 @app.get("/movies/", response_model=list[schemas.MovieSchema])
 def search_movies(title: str, db: Session = Depends(get_db)):
     movies = crud.cache_get_movie_by_title(db, title.strip('"'))
+    if not movies:
+        raise HTTPException(status_code=404, detail="No film found.")
+    return movies
+
+@app.get("/profile_start")
+def profile_start(_request: Request):
+    global profiler
+    if profiler is None:
+        profiler = cProfile.Profile()
+    profiler.enable()
+    return "ok"
+
+@app.get("/profile_stop")
+def profile_stop(_request: Request):
+    global profiler
+    if profiler is not None:
+        profiler.disable()
+        with tempfile.NamedTemporaryFile() as tfile:
+            profiler.dump_stats(tfile.name)
+            ts = datetime.now()
+            return Response(
+                tfile.read(),
+                headers={'content-disposition': f'attachment; filename=profile_{ts:%Y-%m-%dT%H-%M-%S}.cprofile'},
+                media_type='application/octet-stream'
+            )
+        
+        
+    raise HTTPException(status_code=400, detail="No profile started.")
+    
+@app.get("/stats")
+def get_stats(_request: Request):
+    return crud.stats
+
+@app.get("/stats/reset")
+def reset_stats(_request: Request):
+    crud.stats['total'] = 0
+    crud.stats['cached'] = 0
+    return "ok"
+
+@app.get("/mock")
+def mock_search_movies(title: str, response_model=list[schemas.MovieSchema]):
+    movies = mock.get_movies(next(mock_movies))
     if not movies:
         raise HTTPException(status_code=404, detail="No film found.")
     return movies

--- a/app/mock.py
+++ b/app/mock.py
@@ -1,0 +1,38 @@
+from itertools import islice
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.expression import select, tablesample
+
+from app.schemas import MovieSchema
+from . import models
+
+class MockMovie:
+    def __init__(self, row):
+        # just copy all attributes
+        for attr in ('id', 'title', 'year', 'duration', 'rating', 'num_votes', 'directors', 'actors'):
+            setattr(self, attr, getattr(row, attr))
+
+def gen_mocks(db: Session, count=100) -> list[list[MockMovie]]:
+    # select some titles
+    titles = db.execute(select(tablesample(models.Movie, 0.06).c.title))
+    result = []
+    # take at most `count` titles, generate list of responses for each corresponding search query
+    for (title, ) in islice(titles, count):
+        movs = db.query(models.Movie).filter(models.Movie.title.ilike(f'%{title}%')).all()
+        # create mock object out of each orm object
+        result.append(list(map(MockMovie, movs)))
+
+    return result
+
+def get_movies(movies):
+    if movies:
+        schema_movies = []
+        for m in movies:
+            if isinstance(m.directors, str):
+                m.directors = [d.strip() for d in m.directors.split(",")]
+            if isinstance(m.actors, str):
+                m.actors = [a.strip() for a in m.actors.split(",")]
+
+            schema_movies.append(MovieSchema.model_validate(m))
+
+        return [m.model_dump() for m in schema_movies]
+    return None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   db:
@@ -35,10 +35,16 @@ services:
       POSTGRES_HOST: db
       POSTGRES_PORT: 5432
     volumes:
-      - ./app:/app/app
-      - ./scripts:/app/scripts
       - ./data:/app/data
     working_dir: /app
+    develop:
+      watch:
+        - action: sync+restart
+          path: app
+          target: /app/app
+        - action: sync+restart
+          path: scripts/startup.sh
+          target: /app/scripts/startup.sh
 
 volumes:
   imdb_data:

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,16 +1,5 @@
 set -e
 
-echo "Downloading IMDb data..."
-mkdir -p data
-cd data
-wget -q https://datasets.imdbws.com/title.basics.tsv.gz
-wget -q https://datasets.imdbws.com/title.ratings.tsv.gz
-wget -q https://datasets.imdbws.com/title.principals.tsv.gz
-wget -q https://datasets.imdbws.com/name.basics.tsv.gz
-
-gunzip -f *.tsv.gz
-cd ..
-
 echo "Checking if database is already populated..."
 export PGPASSWORD="$POSTGRES_PASSWORD"
 exists=$(psql -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -t -c "SELECT COUNT(*) FROM movies;" 2>/dev/null || echo "error")
@@ -21,6 +10,17 @@ echo "Found $exists rows in 'movies' table."
 if echo "$exists" | grep -Eq '^[0-9]+$' && [ "$exists" -gt 100 ]; then
   echo "Database already populated. Skipping import."
 else
+  echo "Downloading IMDb data..."
+  mkdir -p data
+  cd data
+  wget -N -q https://datasets.imdbws.com/title.basics.tsv.gz
+  wget -N -q https://datasets.imdbws.com/title.ratings.tsv.gz
+  wget -N -q https://datasets.imdbws.com/title.principals.tsv.gz
+  wget -N -q https://datasets.imdbws.com/name.basics.tsv.gz
+
+  gunzip -k -f *.tsv.gz
+  cd ..
+
   echo "Populating database..."
   python -m app.populate_db
 fi


### PR DESCRIPTION
- **add test endpoints /stats, /profile\* and /mock**
  - **/stats**: stats on cache hits; GET `/stats/reset` to set counters to 0
  - **/profile_start, /profile_stop**: start and stop profiling with cProfile; downloads report to be opened with python's `pstats.Stats`
  - **/mock**: imitates `/movies` endpoint but does not access DB at all (precomputes a small set of mock queries at startup)
- **changes to docker-compose and startup script**
  - do not mount volumes for scripts/ and app/, use watch with sync+restart instead
  - check and download data only if DB not initialized, avoid frequent redownloads 
